### PR TITLE
Added initial framework doc for MySQLDump token

### DIFF
--- a/docs/guide/mysql-dump-token.md
+++ b/docs/guide/mysql-dump-token.md
@@ -1,0 +1,18 @@
+# MySQL Dump Token
+
+## What is a MySQL Database Dump Token
+
+This token is a sequence of SQL commands that trigger upon being imported or otherwise executed on a MySQL server. These commands can be optionally obfuscated and/or embedded into a fake SQL dump file with synthetic data.
+
+
+## Creating the token
+
+Create a token by choosing "MySQL Dump" from the drop down list.
+
+Enter your email address or webhook to send alerts to and leave a reasonable comment to remind yourself where you will deploy the token.
+
+You can either copy the generated SQL (encoded or not) into an existing MySQL dump file, or download a randomly-generated one with these commands already embedded.
+
+Leave this token file somewhere with other backups and if an attacker comes across it and imports it to see what it contains you'll be alerted!
+
+


### PR DESCRIPTION
Very initial draft to ensure there is some documentation for the MySQLDump token and the options about encoding the token code and generating a random SQL file versus just providing the few lines to add.