### PR TITLE
Update sensitive cmd install instructions

### DIFF
--- a/docs/guide/sensitive-cmd-token.md
+++ b/docs/guide/sensitive-cmd-token.md
@@ -22,14 +22,17 @@ then click Create:
 <img width="623" alt="image" src="https://user-images.githubusercontent.com/110428675/188696025-b866f09a-29bd-48e8-b4fc-628f7e8ccb2c.png">
 
 
-Download the .reg file and an install it on a Windows 10 or Windows 11 system. 
+Download the .reg file to a Windows system. 
 
 <img width="656" alt="image" src="https://user-images.githubusercontent.com/110428675/188696150-1159b2cd-2e10-469f-8099-bfeebb74ce38.png">
 
 
-You can do this from an Administrative Command Shell.
+In an admin command shell, import the downloaded registry file by running the reg import command twice. The first time to insert registry keys to monitor 64-bit process executions and second time for 32-bit:
 
-`reg import <filepath\filename.reg>`
+```
+reg import <filepath\filename.reg> /reg:64
+reg import <filepath\filename.reg> /reg:32
+```
 
 ## How to use this token 
 


### PR DESCRIPTION
## Proposed changes

On 64-bit machines, the previous installation instructions to monitor process executions would miss 32-bit executions, as this needs different registry keys set. This updates the installation instructions to explicitly install registery keys for both 32 and 64-bit to will ensure the alert always gets triggered.

This resolves https://github.com/thinkst/canarytokens/issues/212.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Linked to the relevant github issue or github discussion

## Further comments

We considered specifying the WOW6432Node version of the registry keys, but that only worked when installed via the 64-bit view of registry. If installed via the 32-bit view, the 64-bit executions would go unmonitored as the un-adorned register key would be redirected to the 32-bit WOW6432Node key (which would just be written twice.)
